### PR TITLE
fixed the extract command when the project contains a directory ending with '.js'

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -153,6 +153,9 @@ function extract(source_path) {
 			strings = [];
 
 		_.each(files, function(file_name) {
+			if (fs.statSync(path.join(source_path, file_name)).isDirectory()) {
+				return;
+			}
 
 			var extension = file_name.split('.').pop(),
 				file_path = path.join(source_path, file_name),


### PR DESCRIPTION
When a project contains a directory ending with the `.js` suffix (yes, I know that it sounds weird, but we sometimes have to deal with external dependencies...), the `extract`command fails:

```
[ERROR] Error: EISDIR, illegal operation on a directory
```

This PR fixes the bug by adding a check on the source type.
